### PR TITLE
DirSource

### DIFF
--- a/src/ice/world/content/blocks/distribution/DirSource.java
+++ b/src/ice/world/content/blocks/distribution/DirSource.java
@@ -67,6 +67,10 @@ public class DirSource extends Block {
         config(int[].class, (DirSourceBuild tile, int[] index) -> {
             tile.index[0] = index[0];
             tile.index[1] = index[1];
+            if (tile.target != null) {
+                tile.target.items.clear();
+                tile.target.liquids.clear();
+            }
         });
     }
 


### PR DESCRIPTION
现在 定向源 会在切换选项后清空原本的物品和液体以避免弹药混用 (因原版炮台对弹药的使用是不依赖于物品模型的，因此这个逻辑对原版炮台通常并不奏效).