### PR TITLE
Add English bundle translations

### DIFF
--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -1,0 +1,515 @@
+
+dialog.contributors.info = Thanks to all developers who participated in the Singularity mod project and all contributors who helped with development.
+dialog.contributors.special = Special thanks to the developers and contributors who provided indispensable help during mod development.
+dialog.contributors.thanks = Finally, thanks to everyone who plays this mod. Recognition of our work is the greatest encouragement. Thank you again for playing!
+
+dialog.liquidSelecting.title = Configure Liquid Output
+dialog.liquidSelecting.output = Output Side
+dialog.liquidSelecting.outputliquid = Liquid
+dialog.liquidSelecting.text = Select the liquid output for the specified direction\nto control liquid output on different sides
+
+dialog.openUriDialog.warning = Connection failed. Link copied to clipboard.
+dialog.openUriDialog.facebook = Facebook Page
+dialog.openUriDialog.telegramPerson = Telegram Profile
+dialog.openUriDialog.telegramGroup = Mod Telegram Group
+dialog.openUriDialog.qqPerson = QQ Profile
+dialog.openUriDialog.qqGroup1 = Mod QQ Group 1
+dialog.openUriDialog.qqGroup2 = Mod QQ Group 2
+
+dialog.dataMonitor.title = Block Data Monitor
+dialog.dataMonitor.blockData = Block Data
+dialog.dataMonitor.target = Target Block
+dialog.dataMonitor.blockPosition = Block Position: ({0}, {1})
+
+dialog.unitFactor.status = Current Status {0}
+dialog.unitFactor.title = Configure Build Queue
+dialog.unitFactor.executing = Executing
+dialog.unitFactor.executed = Executed {0}/{1}
+dialog.unitFactor.queue = Task Queue
+dialog.unitFactor.queueMode = Queue Loop
+dialog.unitFactor.stackMode = Stack Mode
+dialog.unitFactor.skipBlocked = Skip Blocked Tasks
+dialog.unitFactor.makeTask = New Task
+dialog.unitFactor.exported = Queue exported to clipboard
+dialog.unitFactor.imports = Import from Clipboard
+dialog.unitFactor.createAmount = Build Amount {0}
+dialog.unitFactor.timeRemaining = Estimated Time [lightgray]{0}[]
+dialog.unitFactor.taskRemaining = Remaining Tasks [lightgray]{0}/[accent]{1}[]
+dialog.unitFactor.matrixNetLinking = Matrix Network {0}
+dialog.unitFactor.inventory = Inventory Buffer {0}
+dialog.unitFactor.power = Power Grid \n[accent]Power Storage []{0}/{1} {2}[gray]/sec[accent]\n[accent]Work Consumption {3}[gray]/sec
+dialog.unitFactor.energy = Neutron Energy {0}NF[gray]/sec
+dialog.unitFactor.addFaid = Add failed. Queue is full.
+dialog.unitFactor.unresearch = <Locked>
+dialog.unitFactor.movePos = Target Position (x:{0}, y:{1})
+dialog.unitFactor.sort = Sort by [accent]{0}[]
+dialog.unitFactor.order = Ascending
+dialog.unitFactor.reverse = Descending
+dialog.unitFactor.sort_default = Default
+dialog.unitFactor.sort_name = Name
+dialog.unitFactor.sort_size = Size
+dialog.unitFactor.sort_health = Max Health
+dialog.unitFactor.sort_cost = Cost
+dialog.unitFactor.sort_strength = Strength
+dialog.unitFactor.setOutPos = Set Output Position
+
+dialog.publicInfo.getFailed = An exception occurred! Failed to fetch data. Please refresh the page. Details:
+
+dialog.support.info = First, thank you for opening this page. If you like this mod, your support is a great motivation for us to continue this project.
+dialog.support.star = If you want to support this mod, we recommend using the button below to visit the GitHub page and give the project a star.
+dialog.support.githubStar = Go to the mod GitHub page and star it
+dialog.support.donate = If you think our work deserves material support, you can sponsor us through Afdian or Patreon. We do not intend to ask you to pay for our work, but if you are willing to support what we do, we will be extremely grateful.
+dialog.support.afdian = Players from China can sponsor us through Afdian
+dialog.support.patreon = Sponsor us through Patreon
+
+dialog.techtree.title = Tech Tree
+
+#----------Researches----------#
+research.test-1.name = Test Research 1
+research.test-2.name = Test Research 2
+research.test-3.name = Test Research 3
+research.test-4.name = Test Research 4
+research.test-5.name = Test Research 5
+research.test-6.name = Test Research 6
+research.test-7.name = Test Research 7
+research.test-8.name = Test Research 8
+research.test-9.name = Test Research 9
+research.test-10.name = Test Research 10
+research.test-11.name = Test Research 11
+research.test-12.name = Test Research 12
+research.test-13.name = Test Research 13
+research.test-14.name = Test Research 14
+
+research.inspire.placeBlock = Place one {0}
+research.inspire.placeBlocks = Place {0} {1}
+research.inspire.createUnit = Build one {0}
+research.inspire.createUnits = Build {0} {1}
+
+#----------Fragment----------#
+fragment.bars.consume = Input
+fragment.bars.product = Output
+
+fragment.bars.gasPressure = Gas Pressure
+
+fragment.bars.nuclearEnergy = Nuclear Energy
+fragment.bars.potentialNuclearEnergy = Potential Energy
+fragment.bars.nuclearPressure = Potential Energy Level: {0} L
+fragment.buttons.nuclearOut = Output Potential Energy: {0} NE
+fragment.buttons.selectPrescripts = Select Recipe
+fragment.buttons.selectMine = Select Ore
+fragment.buttons.energyOut = Output Nuclear Energy: {0} NF/s
+
+bar.numprogress = Progress: {0}%
+bar.pumpSpeed = Pump Speed {0}/sec
+bar.scale = Fuel Multiplier: {0}x Power Multiplier: {1}x
+bar.destructProgress = Analysis Progress: {0}/{1}
+
+bar.energyBuffered = {0}/{1}
+bar.cellCount = Cell Counter {0}
+bar.launchProgress = Launch Progress {0}%
+bar.energyCons = Matrix Energy Consumption {0}/s ({1}x)
+bar.mirrorshieldhealth = Mirror Shield: {0}
+
+fragment.atmosphere.info = Atmosphere Overview
+fragment.atmosphere.unselectPlanet = No planet selected
+fragment.atmosphere.selectInfo = Please select a sector to select a planet
+fragment.atmosphere.sectorsClose = Collapse Sector Browser
+fragment.atmosphere.sectorsList = Sector List
+fragment.atmosphere.sectors = View Sectors
+fragment.atmosphere.infoButton = Atmosphere Info
+fragment.atmosphere.sectorInfo = Sector Overview
+fragment.atmosphere.baseDelta = Base Gas Delta
+fragment.atmosphere.unAnalyze = This sector has not been atmospherically analyzed
+fragment.atmosphere.noneGasDelta = No atmospheric analysis records for this sector
+fragment.atmosphere.deltaTestTip = Use an atmosphere detector in the sector to analyze atmospheric composition and changes
+fragment.atmosphere.gasAnalyzedDelta = Known Delta: {0} /min
+fragment.atmosphere.basePressure = Base Atmospheric Pressure: {0}[gray] KPa Current: {1} KPa
+fragment.atmosphere.ingredients = Atmospheric Composition
+fragment.atmosphere.sectorsClose1 = Close Sector Preview
+
+fragments.configs.nodeConfig = Node Configuration
+
+#----------Warn----------#
+warn.nuclearPressure.highest = [scarlet]Warning! Potential energy is too high. Overpressure hazard.
+warn.publicInfo.connectFailed = Load failed!\nerror:{0}\nPlease check your network or try reconnecting.
+warn.download.failed = Download failed! Info:
+
+#----------Misc----------#
+misc.name = Name
+misc.modInfo = Info
+misc.add = Add
+misc.search = Search
+misc.startGame = Start Game
+misc.backToGame = Back to Game
+misc.modDatabase = Mod Database
+misc.modConfigure = Mod Configuration
+misc.github = GitHub Project
+misc.discord = Discord Forum
+misc.facebook = Facebook Page
+misc.telegram = Telegram Page
+misc.afdian = Afdian
+misc.unlimited = Unlimited
+misc.qq = QQ Page
+misc.later = Later
+misc.fold = Fold
+misc.unfold = Unfold
+misc.aboutMod = About Mod
+misc.publicInfo = Public Info
+misc.exitGame = Exit Game
+misc.about = About Mod
+misc.download = Download
+misc.upload = Upload
+misc.contribute = Support & Donate
+misc.loading = Loading
+misc.current = Current
+misc.clear = Clear
+misc.time = Time
+misc.inspire = Inspiration
+misc.inspirable = Inspirable
+misc.item = Item
+misc.medium = Medium
+misc.conduit = Conduit
+misc.absorbHeat = Absorb Heat
+misc.gas = Gas
+misc.update = Update
+misc.help = Help
+misc.default = Default
+misc.power = Power
+misc.mode = Mode: {0}
+misc.loop = Loop
+misc.input = Input
+misc.output = Output
+misc.acceptor = Receiver
+misc.container = Storage
+misc.refresh = Refresh
+misc.page = Page {0} / {1}
+misc.noInfo = No Data
+misc.exit = Exit
+misc.back = Back
+misc.sure = OK
+misc.downloading = Downloading...
+misc.copy = Copy
+misc.stop = Stop
+misc.reveal = Reveal
+misc.command = Command
+misc.paste = Paste
+misc.range = Range
+misc.open = Open
+misc.close = Close
+misc.cancel = Cancel
+misc.reset = Reset
+misc.temperature = Temperature
+misc.priority = Priority
+misc.efficiency = Efficiency
+
+misc.contact = Contact
+misc.execute = Execute
+misc.import = Import
+misc.export = Export
+misc.extra = Extra
+misc.join = Join
+misc.details = Details
+misc.group = Group
+misc.byte = Byte
+misc.infinity = Unlimited
+misc.perRequest = /request
+misc.perSecond = /sec
+misc.preMin = /min
+misc.max = Max
+misc.optimal = Optimal
+misc.currentMode = Current Mode
+misc.conduitConfig = Conduit Configuration
+misc.selectPrescripts = Select Recipe
+misc.selectMine = Select Ore
+misc.consumeLiquids = Required Liquids
+misc.produceLiquids = Produced Liquids
+misc.otherLiquids = Optional Liquids
+misc.doConsValid = Production Prerequisites
+misc.blackListMode = Blacklist Mode
+misc.whiteListMode = Whitelist Mode
+misc.toTeam = Affect Allies
+misc.toEnemy = Affect Enemies
+misc.expand = Expand
+misc.preferred = Preferred
+misc.alternative = Alternative
+
+misc.recDefault = Restore Defaults
+misc.allDir = Enable All Directions
+misc.clearDir = Clear Current Direction Configuration
+misc.clearAllDir = Clear All Direction Configurations for Current Type
+
+#----------Infromations----------#
+infos.energyContainerLeak = Neutron energy leak {0} NF/sec ~ [lightgray]may generate energy bodies that cause energy damage
+infos.checkUpdate = Check for Updates
+infos.drillRange = Drill Range: {0} tiles
+infos.checkingUpgrade = Checking for Updates
+infos.newestVersion = Latest Version
+infos.hasUpdate = Available update found: {0}
+infos.openAddress = Open-source address of the mod
+infos.discord = Singularity Discord Chat
+infos.modPage = Mod Page
+infos.mainMenu = Main Menu
+infos.authorPage = Author Page
+infos.nonCons = [lightgray]When required consumptions are not met:[]\n{0}
+infos.facebook = Author Facebook Page
+infos.telegram = Mod Telegram Group
+infos.waiting = [accent]Waiting...[]
+infos.noTask = [accent]No Tasks[]
+infos.working = [#98ffa9]Working[]
+infos.cannotDump = [red]Output Blocked[]
+infos.leakMaterial = [red]Missing Materials[]
+infos.storage = Stored
+infos.offline = [red]Offline[]
+infos.connected = [#98ffa9]Connected[]
+infos.qq = Tencent QQ group for this mod
+infos.pumpMode = Pump Mode
+infos.compressing = Compression mode, pressurizing
+infos.pumpAtomGassing = Extracting gas from the atmosphere
+infos.selectMode = Selection Mode
+infos.selecting = Add mode. Select an area to configure.
+infos.deselecting = Remove mode. Select an area to remove configuration.
+infos.outputMode = Output Mode
+infos.inputMode = Input Mode
+infos.touchShowDetails = Click to toggle detailed/brief view
+infos.blocking = Upstream Flow Blocked
+infos.disabled = Disabled
+infos.placeValid = Placement Available
+infos.placeInvalid = Placement Invalid
+infos.doDestruct = Perform atomic structure analysis in the destructor
+infos.floorEfficiency = Covered Floor Efficiency
+infos.busCount = Link Count
+infos.compBusTopology = A continuous group of connected bus blocks occupies 2 topology space
+infos.curtainAmmo = Release graphite dust to create a persistent electromagnetic interference field
+infos.graphiteEmpAmmo = Release a conductive electromagnetic pulse graphite cloud, continuously dealing electronic damage to enemies in range
+infos.attenuationWithTime = Effect attenuates over time
+infos.placeAreaInvalid = Placement area invalid
+infos.areaOverlaped = Area overlapped
+infos.shots = Shots {0}x
+infos.attach = Contact
+infos.cellYears = Cell age {0}
+infos.cellYearsOverflow = When cell age exceeds the limit, cells age and become disabled
+infos.firstCells = Initial cell count: {0}
+infos.gridLaunchCons = Launch consumption: {0}
+infos.mixedItemCapacity = {0} items / max {1}
+infos.phaseRadarEff = [lightgray]Lock strength = 0.05*log1.01(phase radar unit count + 1) [gray]Multiple radar groups use the maximum lock strength[]
+infos.winterAmmo = Deploys an extreme-cold field\n  [accent]720[lightgray] area damage/sec ~ range 50 tiles (shrinks over time)\n  [accent]Frost[lightgray] intensity +2.5/sec\n  Lasts [accent]10[lightgray] seconds
+infos.heatAmmo = [accent]Meltdown[] intensity +~{0} sec\n[lightgray]Extra damage: [accent]{1}[lightgray]*[accent]Meltdown[lightgray] duration - cap [accent]{2}[lightgray]
+infos.holdShowed = Keep target info displayed
+infos.empDamagedInfo = This effect lasts indefinitely until the unit fully repairs its electronic damage
+infos.zoomMobile = Swipe up and down to zoom
+infos.zoomDesktop = Scroll the mouse wheel to zoom
+infos.holdShowRang = Show all information within the configured range
+infos.holdShowAll = Show all unit information
+infos.holdOff = Do not keep information displayed
+infos.banedAbilities = All abilities disabled
+infos.changeMode = Switch info display mode
+infos.showInfos = Show object info
+infos.hideInfos = Hide object info
+infos.blockDisabled = This facility has been disabled. Please remove it manually.
+infos.resizeInfoScl = Set info scale
+infos.lockingMult = (100 + 0.12*lock strength)%
+infos.lockingProb = (10 + lock strength)%
+infos.andMore = ...[lightgray]{0} entries folded
+infos.override = Override
+infos.append = Append
+infos.modInterop = Mod Interop API
+infos.debug = Debug
+infos.damageAttenuationWithDist = Damage attenuates with distance
+infos.generateLightning = [accent]Release lightning {0}/sec[lightgray] ~[accent]{1}[lightgray] damage[]
+infos.mirageLightningDamage = [lightgray]Reacts with the farthest other crystal shard within [accent]{0}[lightgray] tiles and releases an arc\n[accent]{1}[lightgray] arc damage\n[accent]Also reacts with targets carrying {2}[]
+infos.mustModifyFileWarn = [crimson]Disabling the mod main menu requires changing the config file to show this page again[]
+infos.reciprocalWarn = [crimson]This option has major effects\nDo not change it unless you know what you are doing[]
+infos.unusableDebugButton = [gray]Debug mode cannot be enabled in-game\nPlease change the config file[]
+infos.frostInfo = [gray]When intensity reaches (unit size*30 + unit max health/unit size), the unit will receive an equal duration of[]
+infos.frostFreezeInfo = [gray]When intensity reaches (unit size*60 + 3*unit max health/unit size), the unit dies immediately[]
+infos.meltdownDamage = [gray]Meltdown intensity*10/sec[]
+infos.requireMasterDevice = Must be placed near the master device
+infos.wenUnitIsFlying = When the unit is flying
+infos.buildableList = Buildable List
+infos.matrixDistOnly = Construction materials can only be supplied through the matrix logistics network
+infos.requireRelaunch = Restart Required
+infos.relaunchEnsure = Some settings require a restart to take effect
+infos.confirmResetConfig = All mod configuration items will be restored to defaults. Continue?
+infos.copyToClip = Content copied to clipboard
+infos.clickToPage = Click to open GitHub page:
+infos.selectAItem = Please select a target
+infos.flipCfg = Direction Configuration Tool
+infos.overloadWarn = Warning! Neutron transfer pressure is too high
+
+infos.researchCompleted = Research Complete!
+infos.researched = You have completed research on {0}
+infos.unlocked = Content Unlocked
+infos.inspired = Inspired!
+infos.inspiredBy = Research related to {0} has made great progress
+infos.researchInspired = Major research progress!
+infos.notificationHistory = Log
+infos.logItems = {0} log entries total
+infos.saveLatest100 = Keep the latest 100 entries
+
+infos.structInvalid = Structure Invalid
+infos.recoolanting = Shutting Down
+
+infos.netInvalid = [red]Network Unavailable[]
+infos.topologyInvalid = [red]Insufficient Network Topology Space[]
+infos.energyInvalid = [red]Insufficient Energy[]
+
+infos.title.normal = Announcement
+infos.msgTag.updateLog = Update log or preview for this version
+infos.title.updateLog = Update Log
+infos.msgTag.note = This is noteworthy information that may affect your gameplay
+infos.title.note = Notes
+infos.msgTag.errorWarn = Known serious issue warning. Please read carefully.
+infos.title.errorWarn = Warning
+
+#----------Data---------#
+data.position = Position: ({0}, {1})
+data.ioFlow = Uplink {0} - Downlink {1}
+data.container = Used {0}/{1} - Remaining {2} ({3}%)
+data.buffer = Peak Usage {0} - Max {1}
+data.tasks = Active {0} - Blocked {1} - Dormant {2}
+data.topology = Topology Space Used {0}/{1}
+data.bulletDeflectAngle = Projectile Deflection {0}
+
+#----------Status----------#
+status.ordinary = Normal
+status.energyLeak = Insufficient Energy
+status.topologyLeak = Insufficient Topology Space
+status.bufferBlocked = Buffer Blocked
+status.requestBlocked = Request Blocked
+status.unknow = Unknown
+
+#----------Settings----------#
+settings.singularity = Singularity Settings
+
+settings.category.general = General Settings
+settings.category.graphic = Graphics Settings
+settings.category.advance = Advanced Settings
+
+
+settings.item.maxNotifyHistories = Maximum notification log entries to keep
+settings.item.defaultCameraPos = Default background star-map camera position
+
+
+settings.item.maxDisplay = Maximum displayed objects
+settings.item.showInfoScl = Object info display scale
+settings.item.holdDisplayRange = Hold-display range
+settings.item.healthBarStyle = Health bar style
+settings.item.statusSize = Status icon size
+settings.item.showStatusTime = Show status effect duration
+settings.item.resetModHint = Reset mod hints
+settings.item.resetAllHint = Reset all hints
+
+
+settings.item.enableModsInterops = Enable mod interop API
+settings.item.interopAssignUnitCosts = Interop API: enable unit build cost model registration
+settings.item.interopAssignEmpModels = Interop API: enable unit EMP health model registration
+settings.item.modReciprocal = Allow mods to change game program-level behavior
+settings.item.modReciprocalContent = Allow mods to change vanilla game content
+settings.item.loadInfo = Print loading information
+settings.item.debugMode = Debug Mode
+
+settings.graph_0 = Very Low
+settings.graph_1 = Low
+settings.graph_2 = Medium
+settings.graph_3 = High-Medium
+settings.graph_4 = High
+settings.graph_5 = Custom
+
+settings.resetHintsConfirm = This will reset the hint texts you have completed or manually closed for this mod. You will receive them again when performing specific actions. Continue?
+settings.resetAllHintsConfirm = This will reset all hint texts you have completed or manually closed. You will receive them again when performing specific actions. Continue?
+settings.reset = Reset
+settings.setCamPos = Set Coordinates
+
+#----------Unclassified----------#
+github.mod.source = GitHub Project Source
+groups.qq.develops = Mindustry Mod Development QQ Group
+
+stat.componentbelongs = Component Belongs To
+stat.maxchildrennodes = Total Maximum Connection Points
+stat.linkdirections = Required Link Directions
+stat.matrixenergyuse = Matrix Energy Consumption
+stat.matrixenergycapacity = Energy Capacity
+stat.topologyuse = Topology Space Used
+stat.buffersize = Buffer Size
+stat.computingpower = Computing Power
+stat.topologycapacity = Topology Capacity
+stat.drillsize = Mining Range
+stat.drillmovemulti = Drill Movement Speed Multiplier
+stat.drillangle = Mining Angle
+stat.piercebuild = Mine Through Buildings
+stat.matrixenergyusemulti = Matrix Energy Consumption Multiplier
+stat.maxmatrixlinks = Maximum Node Links
+stat.damageprobably = Damage Chance
+stat.recipes = Available Processes
+stat.effect = Effect
+stat.special = Special
+stat.autoselect = Auto Select
+stat.controllable = Controllable Recipe
+stat.heatproduct = Heat Generated
+stat.maxheat = Maximum Heat
+stat.energycapacity = Energy Capacity
+stat.energyresident = Neutron Damping
+stat.basicpotentialenergy = Base Potential Energy
+stat.minenergypotential = Minimum Potential Energy
+stat.maxenergypotential = Maximum Adjustable Potential Energy
+stat.maxenergypressure = Maximum Neutron Energy Pressure
+stat.consumeenergy = Neutron Energy Consumption
+stat.productenergy = Neutron Energy Output
+stat.damagedmultiplier = Damage Amplification Multiplier
+stat.exdamagemultiplier = Damage Multiplier
+stat.exshielddamage = Shield Damage
+stat.multiple = Multiplier
+stat.maxtarget = Maximum Targets
+stat.coatingtime = Coating Time
+stat.bulletcoating = Projectile Coating
+stat.expierce = Extra Pierce Targets
+stat.maxcoatingbuffer = Maximum Projectile Coating Buffer
+stat.launchtime = Launch Time
+stat.launchconsume = Launch Consumption
+stat.flushtime = Refresh Interval
+stat.maxcellyears = Maximum Cell Lifespan
+stat.gridsize = Grid Size
+stat.emphealth = Maximum System EMP Tolerance
+stat.emparmor = EMP Shielding Strength
+stat.emprepair = System Self-Repair
+stat.sizelimit = Maximum Construction Size
+stat.healthlimit = Maximum Target Health for Construction
+stat.buildlevel = Construction Level
+stat.fieldstrength = Field Strength
+stat.albedo = Albedo
+
+unit.neutronflux = NF
+unit.neutronfluxpresec = NF/sec
+unit.neutronpotentialenergy = NE
+unit.matrixenergy = ME
+unit.heat = J
+unit.heatpresec = J/sec
+unit.byte = Byte
+unit.bytepresec = Byte/s
+
+category.matrix = Matrix
+category.heat = Thermal
+category.other = Other
+
+bullet.empDamage = [accent]{0}[lightgray] EMP damage[]{1}
+bullet.empDamageMulti = EMP Damage Multiplier
+
+hint.last = Previous
+hint.next = Next
+
+hints.doc.nuclearGuidance = Neutron Industry Safety Production Regulations
+
+hints.nuclearEnergyGuidance = [lightgray]Facilities with neutron energy use a special energy supply mode. For details and rules about neutron energy, see [accent]Neutron Industry Safety Production Regulations[lightgray]
+
+hints.spliceStructure-0 = [lightgray]Some buildings can splice with nearby buildings. Usually, when they are [accent]spliced[lightgray] together, their edges change and appear connected into one whole. Some buildings have specific splicing forms; generally, two spliceable buildings must be placed [accent]face-to-face[lightgray] to be treated as one structure.
+hints.spliceStructure-1 = [lightgray]Spliced structures provide special properties, which can be viewed in the building [accent]details[lightgray]. Note that spliced structures have a [accent]maximum structure size[lightgray] limit. Exceeding this range may cause cutting, invalid structures, or other results depending on the case.\n[gray]This guide has no required objective. If you understand it, manually skip this hint.
+
+hints.matrixCorePlaced-0 = [accent]Matrix Core Server[lightgray] is the core device of a matrix network. A matrix network [accent]must have exactly one[lightgray] core server.\nAfter placing a control core, use [accent]Matrix Bridges[lightgray] to link devices in the matrix network. The minimum active matrix network consists of one core and one [accent]valid energy manager[lightgray] connected by a matrix bridge.
+hints.matrixCorePlaced-1 = [lightgray]As shown in the demonstration, connect an [accent]Energy Manager[lightgray] to the Core Server using a Matrix Bridge in a similar form, and use a [accent]Power Interface[lightgray] to supply power to the Energy Manager.
+hints.matrixUsageTip-0 = [lightgray]A matrix network can link multiple devices outward, and each device consumes [accent]topology space[lightgray]. When topology space is full, adding new devices will invalidate the network.\nAdditionally, most devices upload requests to the core. The [accent]computing power[lightgray] of the Matrix Core Server is limited, determining how many task requests your network can process at the same time.
+hints.matrixUsageTip-1 = [lightgray]You can install components around the Core Server to increase the network's [accent]maximum topology capacity[lightgray] and [accent]core computing power[lightgray], as shown in the demonstration.\n[gray]This guide has no required objective. If you understand it, manually skip this hint.
+hints.matrixGridPlaced-0 = [accent]Matrix Grid[lightgray] is the most efficient [accent]logistics I/O management device[lightgray] in a matrix network. It connects with grid frames to form a [accent]closed area[lightgray], where network I/O points and container markers can be configured.
+hints.matrixGridPlaced-1 = [lightgray]To build a valid matrix grid, place several [accent]Grid Frames[lightgray] and connect them one-to-one in a cross pattern with the Grid Controller to form a closed area, as demonstrated.\nThe maximum number of frames that can connect to one grid edge depends on the [accent]Grid Controller[lightgray] used. The basic maximum link count is 8.
+hints.matrixGridActivating-0 = [lightgray]The Matrix Grid can configure [accent]valid containers[lightgray] and [accent]I/O ports[lightgray] within its enclosed area to perform intelligent logistics distribution.
+hints.matrixGridActivating-1 = [lightgray]After the Matrix Grid is built successfully, valid containers and I/O ports in its enclosed area can be configured. For example, place a [accent]Universal I/O Port[lightgray] in the closed area, then click the [accent]Grid Controller[lightgray] first and click the I/O Port to open the configuration panel.\nThis also works for valid containers in the area, such as cores and warehouses.
+hints.matrixGridActivating-2 = [lightgray]After opening the configuration panel, use the buttons on the panel to configure I/O. Click [accent]OK[] to finish configuring a single target. If no item is set, the configuration will be cleared and removed.\nFor more information about this panel, click the [accent]i[] button on the panel.


### PR DESCRIPTION
## Summary

Adds a base English/default Mindustry bundle at `assets/bundles/bundle.properties`.

The new bundle mirrors `bundle_zh_CN.properties` key-for-key so non-Chinese locales have proper English/default text instead of relying on Chinese strings or JSON fallback values.

## Mindustry bundle compatibility

- Uses the standard Mindustry mod bundle path: `assets/bundles/bundle.properties`.
- Keeps the same 458 translation keys as `bundle_zh_CN.properties`.
- Preserves placeholder tokens such as `{0}` and `{1}`.
- Preserves Mindustry rich text tags and escaped newlines such as `[accent]`, `[lightgray]`, and `\n`.

## Verification

- Compared English and Chinese bundle keys: same key count and same order.
- Checked placeholder parity between Chinese and English values.
- Checked that the English bundle contains no CJK characters.
- Confirmed against Mindustry source behavior:
  - `mindustry.mod.Mods` loads `assets/bundles/bundle*.properties` into the bundle chain.
  - `mindustry.mod.ContentParser` only falls back to JSON `name` / `description` when bundle keys are absent.

## Notes

This PR only adds the base English bundle. Chinese translations are left unchanged.
