### PR TITLE
Add English localization for liquids

### DIFF
--- a/src/ice/content/ILiquids.kt
+++ b/src/ice/content/ILiquids.kt
@@ -36,6 +36,10 @@ object ILiquids :Load {
         this.localizedName = "腐殖浆体"
         description = "一种富含有机质的浆体,可用于土壤改良"
       }
+      en {
+        localizedName = "Humus Slurry"
+        description = "An organic-rich slurry that can be used for soil improvement."
+      }
     }
     viscosity = 0.6f
     temperature = 0.3f
@@ -45,6 +49,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "温热孢液"
         description = "一种温暖的孢子悬浮液,具有生物活性"
+      }
+      en {
+        localizedName = "Warm Spore Fluid"
+        description = "A warm spore suspension with biological activity."
       }
     }
     temperature = 0.8f
@@ -57,6 +65,10 @@ object ILiquids :Load {
         this.localizedName = "芥蒂液"
         description = "一种灰色的中性液体,可用于中和反应"
       }
+      en {
+        localizedName = "Cress Liquid"
+        description = "A gray neutral liquid that can be used in neutralization reactions."
+      }
     }
     viscosity = 0.4f
     temperature = 0.5f
@@ -66,6 +78,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "废水"
         description = "一种由工业生产排放的强放射性废水,被其污染过的地区极难再次使用"
+      }
+      en {
+        localizedName = "Wastewater"
+        description = "Highly radioactive wastewater discharged from industrial production. Areas contaminated by it are extremely difficult to reuse."
       }
     }
     incinerable = false
@@ -79,6 +95,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "浓稠血浆"
         description = "从朔方蔓延而来"
+      }
+      en {
+        localizedName = "Thick Plasma"
+        description = "It spreads from the far north."
       }
     }
     nutrientConcentration = 0.2f
@@ -98,6 +118,10 @@ object ILiquids :Load {
         this.localizedName = "急冻液"
         description = "由低温化合物与冷却液混合而成,比冷却液效果更强"
       }
+      en {
+        localizedName = "Swift Cryofluid"
+        description = "Made by mixing cryogenic compounds with cryofluid. It provides stronger cooling than ordinary cryofluid."
+      }
     }
     lightColor = Color.valueOf("E1E9F09A")
     effect = StatusEffects.freezing
@@ -111,6 +135,10 @@ object ILiquids :Load {
         this.localizedName = "灵液"
         description = "一种酸性极强的溶液,可以用来处理金属"
       }
+      en {
+        localizedName = "Ichor"
+        description = "An extremely acidic solution that can be used to process metals."
+      }
     }
     viscosity = 0.7f
     boilPoint = 1.7f
@@ -121,6 +149,11 @@ object ILiquids :Load {
         this.localizedName = "血肉赘生物"
         description = "一种高温且易燃易爆的烈性流体,制取或运输该液体时,请使用专用管道!"
         details = "[red]鲜血必将流淌[]"
+      }
+      en {
+        localizedName = "Flesh Slime"
+        description = "A hot, highly flammable and explosive fluid. Use dedicated conduits when producing or transporting it!"
+        details = "[red]Blood shall flow[]"
       }
     }
     incinerable = false
@@ -147,6 +180,10 @@ object ILiquids :Load {
         this.localizedName = "超临界流体"
         description = "一种通过复杂工业化处理萃取出的特殊流体,具有良好的传质、传热及溶解性能"
       }
+      en {
+        localizedName = "Supercritical Fluid"
+        description = "A special fluid extracted through complex industrial processing, with excellent mass transfer, heat transfer and dissolving properties."
+      }
     }
     incinerable = false
     lightColor = Color.valueOf("E1776A9A")
@@ -162,6 +199,10 @@ object ILiquids :Load {
         this.localizedName = "暮光液"
         description = "暮光液"
       }
+      en {
+        localizedName = "Dusk Liquid"
+        description = "Dusk liquid."
+      }
     }
     temperature = 0.2f
   }
@@ -172,6 +213,11 @@ object ILiquids :Load {
           this.localizedName = "纯净水"
           description = "分离掉其中的杂质的水,在各类严格的流程中是必要的"
           details = "为避免引入杂质,作为溶剂的水必须经过净化去除其中可能影响产品质量的其他物质"
+        }
+        en {
+          localizedName = "Purified Water"
+          description = "Water with impurities removed. It is necessary in many strict production processes."
+          details = "To avoid introducing impurities, water used as a solvent must be purified to remove other substances that may affect product quality."
         }
       }
       heatCapacity = 0.45f
@@ -202,6 +248,11 @@ object ILiquids :Load {
         description = "藻类微生物繁衍的集合体,用途广泛"
         details = "微生物在极端恶劣的环境下会脱去水分进入休眠状态,抗逆性极大提高"
       }
+      en {
+        localizedName = "Algae Mud"
+        description = "A colony of algae microorganisms with a wide range of uses."
+        details = "Microorganisms can dehydrate and enter dormancy under extremely harsh conditions, greatly improving their stress resistance."
+      }
     }
     heatCapacity = 0.4f
     explosiveness = 0f
@@ -231,6 +282,11 @@ object ILiquids :Load {
         description = "复合酸液,工业用途广泛,金属冶炼和物质合成都不可或缺"
         details = "\"当心腐蚀\"\n\"穿戴防护措施\"\n\"挥发性\""
       }
+      en {
+        localizedName = "Acid"
+        description = "A composite acid with broad industrial uses, indispensable for metal smelting and material synthesis."
+        details = "\"Corrosive\"\n\"Wear protective equipment\"\n\"Volatile\""
+      }
     }
     heatCapacity = 0.5f
     temperature = 0.45f
@@ -250,6 +306,11 @@ object ILiquids :Load {
         description = "复合碱液,工业用途广泛,金属冶炼和物质合成都不可或缺"
         details = "\"当心腐蚀\"\n\"穿戴防护措施\"\n\"挥发性\""
       }
+      en {
+        localizedName = "Lye"
+        description = "A composite alkaline solution with broad industrial uses, indispensable for metal smelting and material synthesis."
+        details = "\"Corrosive\"\n\"Wear protective equipment\"\n\"Volatile\""
+      }
     }
     temperature = 0.45f
     flammability = 0f
@@ -267,6 +328,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "氯化硅溶胶"
         description = "富含硅的胶状化合物,易富集硅元素,可用于制造硅或者气凝胶"
+      }
+      en {
+        localizedName = "Silicon Chloride Sol"
+        description = "A silicon-rich gel compound that readily concentrates silicon and can be used to produce silicon or aerogel."
       }
     }
     heatCapacity = 0.65f
@@ -288,6 +353,11 @@ object ILiquids :Load {
         details =
           "通常来说在自然地壳中的金属矿物会有一定的富集作用,往往矿物集团伴生的金属种类不会很多,但在软流层上部这一规律似乎就不适用了,岩浆流会把各种矿物搅和在一起,在靠近那里开采的矿石里几乎什么都能弄到"
       }
+      en {
+        localizedName = "Mixed Ore Solution"
+        description = "A salt solution containing various mineral ions. Electrolysis can yield various metal products."
+        details = "In general, metallic minerals in the natural crust tend to be enriched to some degree, and associated mineral groups usually do not contain too many metal types. This rule, however, seems not to apply near the upper asthenosphere. Magma flows mix all kinds of minerals together, so ores mined near there can contain almost anything."
+      }
     }
     heatCapacity = 0.6f
     temperature = 0.65f
@@ -306,6 +376,10 @@ object ILiquids :Load {
         this.localizedName = "铀盐溶液"
         description = "富含大量铀金属离子的溶液,是铀矿物处理的中间物"
       }
+      en {
+        localizedName = "Uranium Salt Solution"
+        description = "A solution rich in uranium metal ions, used as an intermediate in uranium ore processing."
+      }
     }
     heatCapacity = 0.6f
     temperature = 0.65f
@@ -322,6 +396,11 @@ object ILiquids :Load {
           this.localizedName = "FEX流体"
           description = "经分离杂质后的FEX的原始形态,一种半流体,需要结晶为高纯度的晶体才能满足工业需求"
           details = "流动的越快,流动就会越慢...流动速度会决定FEX的粘度,它会在任何接触的致密介质上发生富集和弱结晶"
+        }
+        en {
+          localizedName = "FEX Fluid"
+          description = "The raw form of FEX after impurities are separated out. It is a semifluid that must crystallize into high-purity crystals to meet industrial requirements."
+          details = "The faster it flows, the slower it flows... Its flow speed determines its viscosity, and it enriches and weakly crystallizes on any dense medium it contacts."
         }
       }
       heatCapacity = 1f
@@ -353,6 +432,11 @@ object ILiquids :Load {
           description = "相位化后的FEX流体,物理性质改变,表面张力有自发性的剧烈波动,且具会与其接触介质发生共振,性能优越的流质能量载体"
           details = "严禁在无谐振防护的情况下靠近储存相位态FEX的储罐或者储液槽"
         }
+        en {
+          localizedName = "Phased FEX Fluid"
+          description = "Phase-shifted FEX fluid with altered physical properties. Its surface tension fluctuates violently on its own and resonates with media it contacts, making it an excellent fluid energy carrier."
+          details = "Do not approach tanks or reservoirs storing phased FEX without resonance protection."
+        }
       }
       heatCapacity = 1.25f
       explosiveness = 0f
@@ -383,6 +467,10 @@ object ILiquids :Load {
         this.localizedName = "氧气"
         description = "最常用的气体,在工业生产中都作为氧化剂"
       }
+      en {
+        localizedName = "Oxygen"
+        description = "The most commonly used gas, serving as an oxidizer in industrial production."
+      }
     }
     gas = true
     explosiveness = 0f
@@ -395,6 +483,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "二氧化碳"
         description = "大气中普遍存在的温室气体,在工业生产中,二氧化碳常被用作制冷剂,惰性保护气体"
+      }
+      en {
+        localizedName = "Carbon Dioxide"
+        description = "A greenhouse gas commonly present in the atmosphere. In industry, carbon dioxide is often used as a refrigerant and inert shielding gas."
       }
     }
     gas = true
@@ -409,6 +501,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "二氧化硫"
         description = "一种氧化性气体,通常用于制备硫酸"
+      }
+      en {
+        localizedName = "Sulfur Dioxide"
+        description = "An oxidizing gas usually used to produce sulfuric acid."
       }
     }
     gas = true
@@ -426,6 +522,10 @@ object ILiquids :Load {
         this.localizedName = "沼气"
         description = "一种天然气体,主要成分是甲烷,可替代部分工厂的燃料需求"
       }
+      en {
+        localizedName = "Methane"
+        description = "A natural gas mainly composed of methane, capable of replacing part of a factory's fuel demand."
+      }
     }
     gas = true
     explosiveness = 0.5f
@@ -438,6 +538,10 @@ object ILiquids :Load {
         this.localizedName = "氢气"
         description = ""
       }
+      en {
+        localizedName = "Hydrogen"
+        description = ""
+      }
     }
     gas = true
     flammability = 1f
@@ -448,6 +552,11 @@ object ILiquids :Load {
         this.localizedName = "氦气"
         description = "较为常见的0族惰性气体,常用作工业保护气或通过中子流轰击生产核聚变燃料"
         details = "一般来说氦气在行星岩层中的分布会比较丰富,由于原子质量过轻,在有大气的行星地表很难大量存在"
+      }
+      en {
+        localizedName = "Helium"
+        description = "A relatively common group 0 inert gas, often used as an industrial shielding gas or produced as fusion fuel through neutron bombardment."
+        details = "Helium is generally abundant in planetary rock layers. Because its atomic mass is too light, it is difficult for large amounts to remain on the surface of planets with atmospheres."
       }
     }
     gas = true
@@ -462,6 +571,10 @@ object ILiquids :Load {
       zh_CN {
         this.localizedName = "氯气"
         description = "生物毒性的气体,水系当中往往含有一定量的氯及其盐离子,工业上十分常用的气体"
+      }
+      en {
+        localizedName = "Chlorine"
+        description = "A biologically toxic gas. Water systems often contain a certain amount of chlorine and chloride ions, making it very common in industry."
       }
     }
     gas = true


### PR DESCRIPTION
## Summary
- Add hardcoded English localization blocks for liquids in `src/ice/content/ILiquids.kt`.
- Follow the existing `localization { zh_CN { ... } en { ... } }` style used by the project.
- Cover all 26 existing liquid localization entries, including names, descriptions, and details where present.

## Verification
- Checked Mindustry `mindustry.type.Liquid` source to verify the content type and localization-relevant fields are valid on liquid content.
- Checked existing project localization examples such as `src/ice/content/IItems.kt` and `src/singularity/contents/LiquidBlocks.kt`.
- Ran static validation:
  - 26 `zh_CN` blocks and 26 `en` blocks in `ILiquids.kt`.
  - Every English block contains `localizedName` and `description`.
  - English blocks contain no CJK characters.
  - Kotlin string quote check passed.
  - `git diff --check` passed.

## Build
- Attempted `bash ./gradlew classes --no-daemon --stacktrace`.
- The command timed out in this environment before producing a build result, consistent with previous Gradle/network limitations here.
